### PR TITLE
feat: add hasCopy, size, clear, renameCopy and performance    improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 - Automatically generates unique copy names in the format `name`, `nameのコピー`, `nameのコピー(2)`, etc.
 - Handles deletion of copies and reuses deleted copy numbers when new copies are added.
+- Supports renaming copies while preserving their position.
 - Supports custom copy suffixes.
 - Provides easy integration with frontend frameworks like React.
 
@@ -136,6 +137,51 @@ Returns an array of all current copy names in insertion order.
 ### `getCopySuffix(): string`
 
 Returns the suffix string currently used when generating copy names.
+
+### `hasCopy(name: string): boolean`
+
+Returns `true` if the specified name exists, `false` otherwise. O(1) lookup.
+
+### `size: number`
+
+Returns the number of current copies.
+
+```ts
+manager.addCopy("Document");
+manager.addCopy("Document");
+console.log(manager.size); // 2
+```
+
+### `clear(): void`
+
+Removes all copies and resets internal state.
+
+```ts
+manager.addCopy("Document");
+manager.clear();
+console.log(manager.getCopies()); // []
+console.log(manager.size); // 0
+```
+
+### `renameCopy(from: string, to: string): string | false`
+
+Renames an existing copy to a new name while preserving its position in the list. Returns the actual new name (may differ from `to` if `to` already exists), or `false` if `from` is not found.
+
+```ts
+manager.addCopy("Document");
+manager.addCopy("Document");
+// ["Document", "Documentのコピー"]
+
+manager.renameCopy("Document", "Report");
+console.log(manager.getCopies()); // ["Report", "Documentのコピー"]
+
+// If the target name already exists, a suffix is appended
+manager.addCopy("File");
+manager.addCopy("File");
+// ["File", "Fileのコピー"]
+const result = manager.renameCopy("File", "Fileのコピー");
+console.log(result); // "Fileのコピーのコピー"
+```
 
 ## License
 

--- a/src/copy-name-manager.test.ts
+++ b/src/copy-name-manager.test.ts
@@ -278,4 +278,137 @@ describe("CopyNameManager", () => {
       expect(copies[copies.length - 1]).toBe(copyName);
     });
   });
+
+  describe("getCopies の不変性", () => {
+    it("戻り値を変更しても内部状態に影響しない", () => {
+      copyNameManager.addCopy("Document");
+      const copies = copyNameManager.getCopies();
+      copies.push("外部から追加");
+      expect(copyNameManager.getCopies()).toEqual(["Document"]);
+      expect(copyNameManager.size).toBe(1);
+    });
+  });
+
+  describe("removeCopy のベース名削除バグ修正", () => {
+    it("ベース名を削除してもコピーの番号追跡が壊れない", () => {
+      copyNameManager.addCopy("Document");
+      copyNameManager.addCopy("Document");
+      copyNameManager.addCopy("Document");
+      // ["Document", "Documentのコピー", "Documentのコピー(2)"]
+      copyNameManager.removeCopy("Document");
+      // copyNumbers["Document"] は {1, 2} のまま保持されるべき
+      copyNameManager.addCopy("Document");
+      // 次のaddCopyは "Documentのコピー" を試みるが既存のため "Documentのコピー(3)" になる
+      const newCopy = copyNameManager.addCopy("Document");
+      expect(copyNameManager.getCopies()).toContain("Documentのコピー");
+      expect(copyNameManager.getCopies()).toContain("Documentのコピー(2)");
+      expect(newCopy).not.toBe("Documentのコピー");
+      expect(newCopy).not.toBe("Documentのコピー(2)");
+    });
+  });
+
+  describe("hasCopy", () => {
+    it("存在するコピーに対して true を返す", () => {
+      copyNameManager.addCopy("Document");
+      expect(copyNameManager.hasCopy("Document")).toBe(true);
+    });
+
+    it("存在しないコピーに対して false を返す", () => {
+      expect(copyNameManager.hasCopy("Document")).toBe(false);
+    });
+
+    it("削除後は false を返す", () => {
+      copyNameManager.addCopy("Document");
+      copyNameManager.removeCopy("Document");
+      expect(copyNameManager.hasCopy("Document")).toBe(false);
+    });
+  });
+
+  describe("size", () => {
+    it("初期状態は 0 を返す", () => {
+      expect(copyNameManager.size).toBe(0);
+    });
+
+    it("addCopy のたびに増加する", () => {
+      copyNameManager.addCopy("Document");
+      expect(copyNameManager.size).toBe(1);
+      copyNameManager.addCopy("Document");
+      expect(copyNameManager.size).toBe(2);
+    });
+
+    it("removeCopy のたびに減少する", () => {
+      copyNameManager.addCopy("Document");
+      copyNameManager.addCopy("Document");
+      copyNameManager.removeCopy("Document");
+      expect(copyNameManager.size).toBe(1);
+    });
+  });
+
+  describe("clear", () => {
+    it("全てのコピーを削除する", () => {
+      copyNameManager.addCopy("Document");
+      copyNameManager.addCopy("Document");
+      copyNameManager.clear();
+      expect(copyNameManager.getCopies()).toEqual([]);
+      expect(copyNameManager.size).toBe(0);
+    });
+
+    it("clear 後に同じ名前を再追加できる", () => {
+      copyNameManager.addCopy("Document");
+      copyNameManager.addCopy("Document");
+      copyNameManager.clear();
+      const name = copyNameManager.addCopy("Document");
+      expect(name).toBe("Document");
+      expect(copyNameManager.getCopies()).toEqual(["Document"]);
+    });
+  });
+
+  describe("renameCopy", () => {
+    it("存在しない名前を変更しようとすると false を返す", () => {
+      expect(copyNameManager.renameCopy("存在しない", "新しい名前")).toBe(
+        false,
+      );
+    });
+
+    it("コピーを別の名前に変更できる", () => {
+      copyNameManager.addCopy("Document");
+      const result = copyNameManager.renameCopy("Document", "Report");
+      expect(result).toBe("Report");
+      expect(copyNameManager.getCopies()).toEqual(["Report"]);
+    });
+
+    it("変更後も同じ位置を保持する", () => {
+      copyNameManager.addCopy("Document");
+      copyNameManager.addCopy("Document");
+      copyNameManager.addCopy("Document");
+      // ["Document", "Documentのコピー", "Documentのコピー(2)"]
+      copyNameManager.renameCopy("Documentのコピー", "Report");
+      expect(copyNameManager.getCopies()[1]).toBe("Report");
+    });
+
+    it("変更先の名前が既に存在する場合はサフィックスを付与する", () => {
+      copyNameManager.addCopy("Document");
+      copyNameManager.addCopy("Report");
+      const result = copyNameManager.renameCopy("Document", "Report");
+      expect(result).toBe("Reportのコピー");
+      expect(copyNameManager.getCopies()).toEqual(["Reportのコピー", "Report"]);
+    });
+
+    it("同じ名前への変更はそのまま返す", () => {
+      copyNameManager.addCopy("Document");
+      const result = copyNameManager.renameCopy("Document", "Document");
+      expect(result).toBe("Document");
+      expect(copyNameManager.getCopies()).toEqual(["Document"]);
+    });
+
+    it("変更後に元の名前でコピーを追加できる", () => {
+      copyNameManager.addCopy("Document");
+      copyNameManager.addCopy("Document");
+      // ["Document", "Documentのコピー"]
+      copyNameManager.renameCopy("Document", "Report");
+      // ["Report", "Documentのコピー"]
+      const name = copyNameManager.addCopy("Document");
+      expect(name).toBe("Document");
+    });
+  });
 });

--- a/src/copy-name-manager.ts
+++ b/src/copy-name-manager.ts
@@ -1,38 +1,43 @@
 class CopyNameManager {
   private copyNumbers: Record<string, Set<number>>;
   private copies: string[];
+  private copiesSet: Set<string>;
   private copySuffix: string;
+  private escapedSuffix: string;
 
   constructor(initialNames: string[] = [], copySuffix = "のコピー") {
     this.copyNumbers = {};
     this.copies = [];
+    this.copiesSet = new Set();
     this.copySuffix = copySuffix;
+    this.escapedSuffix = this.escapeRegExp(copySuffix);
 
     initialNames.forEach((name) => {
       this.addCopy(name);
     });
   }
-  private escapeRegExp(string: string) {
-    return string.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+
+  private escapeRegExp(string: string): string {
+    return string.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&");
   }
 
-  addCopy(name: string): string {
-    const escapedSuffix = this.escapeRegExp(this.copySuffix);
-    const baseName = name.replace(new RegExp(`${escapedSuffix}(\\d*)$`), "");
+  private generateUniqueName(name: string): string {
+    const baseName = name.replace(
+      new RegExp(`${this.escapedSuffix}(\\d*)$`),
+      "",
+    );
     if (!this.copyNumbers[baseName]) {
       this.copyNumbers[baseName] = new Set<number>();
     }
 
     let newCopyName: string;
 
-    if (this.copies.includes(name)) {
-      // 名前が既に存在する場合、「のコピー」形式で新しいコピー名を作成
+    if (this.copiesSet.has(name)) {
       if (!this.copyNumbers[name]?.has(1)) {
         newCopyName = `${name}${this.copySuffix}`;
-        this.copyNumbers[name]?.add(1); // 最初のコピーを予約
+        this.copyNumbers[name]?.add(1);
       } else {
-        // 「のコピー」が存在する場合、次の番号付きコピーを作成
-        let nextCopyNumber = 2; // (2) からスタート
+        let nextCopyNumber = 2;
         while (this.copyNumbers[name]?.has(nextCopyNumber)) {
           nextCopyNumber++;
         }
@@ -40,54 +45,84 @@ class CopyNameManager {
         this.copyNumbers[name]?.add(nextCopyNumber);
       }
     } else {
-      // 名前がまだ使われていない場合、そのままの名前を使用
       newCopyName = name;
     }
 
-    // 新しいコピー名が既存のコピーと競合していないか確認
-    // Check if the new copy name conflicts with existing copies
     let copyNumber = 1;
-    while (this.copies.includes(newCopyName)) {
+    while (this.copiesSet.has(newCopyName)) {
       copyNumber++;
       newCopyName = `${name}${this.copySuffix}(${copyNumber})`;
     }
 
+    return newCopyName;
+  }
+
+  private untrackCopy(name: string): void {
+    const baseName = name
+      .replace(new RegExp(`${this.escapedSuffix}\\(\\d+\\)$`), "")
+      .replace(new RegExp(`${this.escapedSuffix}$`), "");
+
+    if (name === baseName) return;
+
+    const match = name.match(new RegExp(`${this.escapedSuffix}\\((\\d+)\\)$`));
+    const copyNumber = match ? parseInt(match[1] || "", 10) : 1;
+
+    this.copyNumbers[baseName]?.delete(copyNumber);
+  }
+
+  addCopy(name: string): string {
+    const newCopyName = this.generateUniqueName(name);
     this.copies.push(newCopyName);
+    this.copiesSet.add(newCopyName);
     return newCopyName;
   }
 
   removeCopy(name: string): boolean {
-    const index = this.copies.findIndex((copy) => copy === name);
-    if (index > -1) {
-      const [removedCopy] = this.copies.splice(index, 1);
+    const index = this.copies.indexOf(name);
+    if (index === -1) return false;
 
-      if (!removedCopy) {
-        throw new Error("removedCopy is empty");
-      }
+    this.copies.splice(index, 1);
+    this.copiesSet.delete(name);
+    this.untrackCopy(name);
 
-      const escapedSuffix = this.escapeRegExp(this.copySuffix);
-      const baseName = removedCopy
-        .replace(new RegExp(`${escapedSuffix}\\(\\d+\\)$`), "")
-        .replace(new RegExp(`${escapedSuffix}$`), "");
-      const match = removedCopy.match(
-        new RegExp(`${escapedSuffix}\\((\\d+)\\)$`),
-      );
-      const copyNumber = match ? parseInt(match[1] || "", 10) : 1;
+    return true;
+  }
 
-      if (this.copyNumbers[baseName]) {
-        this.copyNumbers[baseName]?.delete(copyNumber);
-      }
+  renameCopy(from: string, to: string): string | false {
+    const index = this.copies.indexOf(from);
+    if (index === -1) return false;
 
-      return true;
-    }
-    return false;
+    this.copiesSet.delete(from);
+    this.untrackCopy(from);
+
+    const newName = this.generateUniqueName(to);
+
+    this.copies[index] = newName;
+    this.copiesSet.add(newName);
+
+    return newName;
   }
 
   getCopies(): string[] {
-    return this.copies;
+    return [...this.copies];
   }
+
   getCopySuffix(): string {
     return this.copySuffix;
+  }
+
+  hasCopy(name: string): boolean {
+    return this.copiesSet.has(name);
+  }
+
+  get size(): number {
+    return this.copies.length;
+  }
+
+  clear(): void {
+    this.copies = [];
+    this.copiesSet = new Set();
+    this.copyNumbers = {};
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hasCopy()` method to check if a copy exists.
  * Added `size` property to retrieve the current copy count.
  * Added `clear()` method to reset all copies to initial state.
  * Added `renameCopy()` method to rename a copy while preserving its list position.

* **Bug Fixes**
  * `getCopies()` now returns a protected copy to prevent unintended external mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->