### PR TITLE
fix: sort copies when reusing deleted copy number

### DIFF
--- a/.changeset/free-sloths-cry.md
+++ b/.changeset/free-sloths-cry.md
@@ -1,0 +1,5 @@
+---
+"@kenmori/copy-name-manager": patch
+---
+
+fix: sort copies when reusing deleted copy number

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        run: gh release create ${{ github.ref_name }} --generate-notes --title "${{ github.ref_name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/copy-name-manager.test.ts
+++ b/src/copy-name-manager.test.ts
@@ -63,8 +63,8 @@ describe("CopyNameManager", () => {
     expect(copyName).toBe("Documentのコピー");
     expect(copyNameManager.getCopies()).toEqual([
       "Document",
-      "Documentのコピー(2)",
       "Documentのコピー",
+      "Documentのコピー(2)",
     ]);
   });
 
@@ -270,12 +270,11 @@ describe("CopyNameManager", () => {
       expect(copyName).toBe("My Documentのコピー");
     });
 
-    it("addCopyの戻り値とgetCopiesの末尾が一致する", () => {
+    it("addCopyの戻り値はgetCopiesに含まれる", () => {
       copyNameManager.addCopy("Document");
       copyNameManager.addCopy("Document");
       const copyName = copyNameManager.addCopy("Document");
-      const copies = copyNameManager.getCopies();
-      expect(copies[copies.length - 1]).toBe(copyName);
+      expect(copyNameManager.getCopies()).toContain(copyName);
     });
   });
 

--- a/src/copy-name-manager.ts
+++ b/src/copy-name-manager.ts
@@ -70,9 +70,38 @@ class CopyNameManager {
     this.copyNumbers[baseName]?.delete(copyNumber);
   }
 
+  private getCopyNumber(name: string, baseName: string): number {
+    if (name === baseName) return 0;
+    const match = name.match(new RegExp(`${this.escapedSuffix}\\((\\d+)\\)$`));
+    return match ? parseInt(match[1]!, 10) : 1;
+  }
+
+  private findInsertIndex(newCopyName: string): number {
+    const baseName = newCopyName
+      .replace(new RegExp(`${this.escapedSuffix}\\(\\d+\\)$`), "")
+      .replace(new RegExp(`${this.escapedSuffix}$`), "");
+
+    if (newCopyName === baseName) return -1;
+
+    const newNumber = this.getCopyNumber(newCopyName, baseName);
+
+    return this.copies.findIndex((copy) => {
+      const copyBase = copy
+        .replace(new RegExp(`${this.escapedSuffix}\\(\\d+\\)$`), "")
+        .replace(new RegExp(`${this.escapedSuffix}$`), "");
+      if (copyBase !== baseName) return false;
+      return this.getCopyNumber(copy, copyBase) > newNumber;
+    });
+  }
+
   addCopy(name: string): string {
     const newCopyName = this.generateUniqueName(name);
-    this.copies.push(newCopyName);
+    const insertIndex = this.findInsertIndex(newCopyName);
+    if (insertIndex === -1) {
+      this.copies.push(newCopyName);
+    } else {
+      this.copies.splice(insertIndex, 0, newCopyName);
+    }
     this.copiesSet.add(newCopyName);
     return newCopyName;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed copy name ordering when reusing previously deleted copy numbers.

* **Chores**
  * Added automated release workflow for version tag-based publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->